### PR TITLE
fix: disable setting pressure to default value on web

### DIFF
--- a/lib/src/view/notifier/scribble_notifier.dart
+++ b/lib/src/view/notifier/scribble_notifier.dart
@@ -427,7 +427,7 @@ class ScribbleNotifier extends ScribbleNotifierBase
 
   /// Converts a pointer event to the [Point] on the canvas.
   Point _getPointFromEvent(PointerEvent event) {
-    final p = kIsWeb || event.pressureMin == event.pressureMax
+    final p = event.pressureMin == event.pressureMax
         ? 0.5
         : (event.pressure - event.pressureMin) /
             (event.pressureMax - event.pressureMin);


### PR DESCRIPTION
On my machine (linux 6.11.5 with google chrome 130.0.6723.91) detecting pressure works flawlessly